### PR TITLE
Reverse parameter order to escape function

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -296,7 +296,7 @@ module internal Escaping =
 
                         escape (r @ n) t
 
-        new string (List.toArray (escape [ for c in s -> c ] []))
+        new string (List.toArray (escape [] [ for c in s -> c ]))
 
 (* Parsing
 
@@ -527,21 +527,6 @@ module Formatting =
         join
 
     (* Formatters *)
-
-    let rec safeString str =
-        str
-        |> Seq.map (fun c ->
-            match c with
-            | '"' -> "\\\""
-            | '\\' -> @"\\"
-            | '\n' -> @"\n"
-            | '\b' -> @"\b"
-            | '\f' -> @"\f"
-            | '\r' -> @"\r"
-            | '\t' -> @"\t"
-            | '\v' -> @"\v"
-            | c -> string c )
-        |> String.concat ""
 
     let rec private formatJson =
         function | Array x -> formatArray x

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -119,7 +119,7 @@ let ``Json.format returns correct values`` () =
     Json.format (String "hello") =? "\"hello\""
     Json.format (String "") =? "\"\""
     Json.format (String "푟") =? "\"푟\""
-    Json.format (String "\t") =? "\"\t\""
+    Json.format (String "\t") =? "\"\\t\""
 
 (* Mapping
 


### PR DESCRIPTION
To avoid it being a very long implementation of ``id``