### PR TITLE
Reverse parameter order to escape function

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,6 +5,7 @@ nuget Freya.Types.Uri 0.9.0-alpha-46
 nuget FParsec
 nuget FSharp.Core
 nuget Fake
+nuget FsCheck
 nuget Nuget.CommandLine
 nuget NUnit
 nuget NUnit.Runners

--- a/paket.lock
+++ b/paket.lock
@@ -11,6 +11,7 @@ NUGET
       FParsec (>= 1.0.1)
       FSharp.Core (>= 3.1.2)
       Freya.Types (>= 0.9.0-alpha-46)
+    FsCheck (1.0.4)
     FSharp.Core (3.1.2.1)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.4)

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -296,7 +296,7 @@ module internal Escaping =
 
                         escape (r @ n) t
 
-        new string (List.toArray (escape [ for c in s -> c ] []))
+        new string (List.toArray (escape [] [ for c in s -> c ]))
 
 (* Parsing
 
@@ -527,21 +527,6 @@ module Formatting =
         join
 
     (* Formatters *)
-
-    let rec safeString str =
-        str
-        |> Seq.map (fun c ->
-            match c with
-            | '"' -> "\\\""
-            | '\\' -> @"\\"
-            | '\n' -> @"\n"
-            | '\b' -> @"\b"
-            | '\f' -> @"\f"
-            | '\r' -> @"\r"
-            | '\t' -> @"\t"
-            | '\v' -> @"\v"
-            | c -> string c )
-        |> String.concat ""
 
     let rec private formatJson =
         function | Array x -> formatArray x

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -659,7 +659,7 @@ module Mapping =
 
         static member inline FromJson (_: DateTime) =
                 fun x ->
-                    match DateTime.TryParseExact (x, [| "r" |], null, DateTimeStyles.None) with
+                    match DateTime.TryParseExact (x, [| "r" |], null, DateTimeStyles.AssumeUniversal) with
                     | true, x -> Json.init x
                     | _ -> Json.error "datetime"
             =<< Json.getLensPartial (stringPLens ())

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -29,11 +29,14 @@ let inline roundTrip (thing : 'a) : 'a =
 
 type ChironProperties =
     static member ``Strings can be roundtripped`` (str : string) =
-        roundTrip str = str
-    static member ``Date times can be roundtripped`` (tr : System.DateTime) =
-        roundTrip tr = tr
+        let sut = roundTrip str
+        sut = str |@ sprintf "(%A should equal %A)" sut str
+    static member ``Date times can be roundtripped`` (dt : System.DateTime) =
+        let sut = roundTrip dt
+        sut = dt |@ sprintf "(%A should equal %A)" sut dt
     static member ``Records can be roundtripped`` (tr : TestRecord) =
-        roundTrip tr = tr
+        let sut = roundTrip tr
+        sut = tr |@ sprintf "(%A should equal %A)" sut tr
 
 type SafeString =
     static member SafeString () =

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -1,0 +1,46 @@
+﻿module Chiron.Properties
+
+open FsCheck
+open NUnit.Framework
+open Chiron
+open Chiron.Operators
+
+type TestRecord =
+    {
+        StringField : string
+        GuidField : System.Guid
+        DateTimeField : System.DateTime
+    }
+    static member FromJson (_ : TestRecord) =
+            fun s g d -> { StringField = s; GuidField = g; DateTimeField = d }
+        <!> Json.read "stringField"
+        <*> Json.read "guidField"
+        <*> Json.read "dateTimeField"
+    static member ToJson { StringField = s; GuidField = g; DateTimeField = d } =
+        Json.write "stringField" s
+        *> Json.write "guidField" g
+        *> Json.write "dateTimeField" d
+
+let inline roundTrip (thing : 'a) : 'a =
+    Json.serialize thing
+    |> Json.format
+    |> Json.parse
+    |> Json.deserialize
+
+type ChironProperties =
+    static member ``Strings can be roundtripped`` (str : string) =
+        roundTrip str = str
+    static member ``Date times can be roundtripped`` (tr : System.DateTime) =
+        roundTrip tr = tr
+    static member ``Records can be roundtripped`` (tr : TestRecord) =
+        roundTrip tr = tr
+
+type SafeString =
+    static member SafeString () =
+        Arb.Default.String()
+        |> Arb.filter (fun s ->
+            s <> null)
+
+[<Test>]
+let ``Chiron properties`` () =
+    Check.All<ChironProperties>({ Config.VerboseThrowOnFailure with Arbitrary = [typeof<SafeString>] })

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -119,7 +119,7 @@ let ``Json.format returns correct values`` () =
     Json.format (String "hello") =? "\"hello\""
     Json.format (String "") =? "\"\""
     Json.format (String "푟") =? "\"푟\""
-    Json.format (String "\t") =? "\"\t\""
+    Json.format (String "\t") =? "\"\\t\""
 
 (* Mapping
 

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj
@@ -57,6 +57,7 @@
   -->
   <ItemGroup>
     <Compile Include="Chiron.Tests.fs" />
+    <Compile Include="Chiron.Properties.fs" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
@@ -75,6 +76,17 @@
       <ItemGroup>
         <Reference Include="Aether">
           <HintPath>..\..\packages\Aether\lib\net40\Aether.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\packages\FsCheck\lib\net45\FsCheck.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
@@ -2,3 +2,4 @@ Aether
 FSharp.Core
 NUnit
 Unquote
+FsCheck


### PR DESCRIPTION
To avoid it being a very long implementation of ``id``