### PR TITLE
switching float to decimal as the underlying json number type, in the in...

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -33,7 +33,7 @@ Target "Publish" (fun _ ->
                   "Michael Newton"
                   "Henrik Feldt" ]
               Project = "Chiron"
-              Version = "3.1.0"
+              Version = "4.0.0"
               OutputPath = "bin"
               AccessKey = getBuildParamOrDefault "nuget_key" ""
               Publish = hasBuildParam "nuget_key"

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -24,7 +24,7 @@ type Json =
     | Array of Json list
     | Bool of bool
     | Null of unit
-    | Number of float
+    | Number of decimal
     | Object of Map<string, Json>
     | String of string
 
@@ -42,7 +42,7 @@ type Json =
         (function | Null () -> Some ()
                   | _ -> None), Null
 
-    static member NumberPIso : PIso<Json, float> =
+    static member NumberPIso : PIso<Json, decimal> =
         (function | Number x -> Some x
                   | _ -> None), Number
 
@@ -65,7 +65,7 @@ type Json =
     static member NullPLens : PLens<Json, unit> =
         idLens <-?> Json.NullPIso
 
-    static member NumberPLens : PLens<Json, float> =
+    static member NumberPLens : PLens<Json, decimal> =
         idLens <-?> Json.NumberPIso
 
     static member ObjectPLens : PLens<Json, Map<string, Json>> =
@@ -445,7 +445,7 @@ module Parsing =
 
     let private numberP =
         pipe4 (opt minusP) intP (opt fracP) (opt expP) (fun m i f e ->
-            float (emp m + i + emp f + emp e)) .>> wspP
+            decimal (emp m + i + emp f + emp e)) .>> wspP
 
     (* Strings
 
@@ -626,11 +626,11 @@ module Mapping =
         static member inline FromJson (_: bool) =
             Json.getLensPartial Json.BoolPLens
 
-        static member inline FromJson (_: decimal) : Json<decimal> =
-            decimal <!> Json.getLensPartial Json.NumberPLens
+        static member inline FromJson (_: decimal) =
+            id <!> Json.getLensPartial Json.NumberPLens
 
         static member inline FromJson (_: float) =
-            id <!> Json.getLensPartial Json.NumberPLens
+            float <!> Json.getLensPartial Json.NumberPLens
 
         static member inline FromJson (_: int) =
             int <!> Json.getLensPartial Json.NumberPLens
@@ -773,34 +773,34 @@ module Mapping =
             Json.setLensPartial Json.BoolPLens x
 
         static member inline ToJson (x: decimal) =
-            Json.setLensPartial Json.NumberPLens (float x)
-
-        static member inline ToJson (x: float) =
             Json.setLensPartial Json.NumberPLens x
 
+        static member inline ToJson (x: float) =
+            Json.setLensPartial Json.NumberPLens (decimal x)
+
         static member inline ToJson (x: int) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: int16) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: int64) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: single) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: string) =
             Json.setLensPartial Json.StringPLens x
 
         static member inline ToJson (x: uint16) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: uint32) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         static member inline ToJson (x: uint64) =
-            Json.setLensPartial Json.NumberPLens (float x)
+            Json.setLensPartial Json.NumberPLens (decimal x)
 
         (* Common Types *)
 

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -13,12 +13,12 @@ open Swensen.Unquote
 let private t1 =
     Object (Map.ofList
         [ "bool", Bool true
-          "number", Number 2. ])
+          "number", Number 2M ])
 
 let private t2 =
     Object (Map.ofList
         [ "bool", Bool false
-          "number", Number 2. ])
+          "number", Number 2M ])
 
 (* Functional
 
@@ -135,15 +135,15 @@ let ``Json.deserialize simple types returns correct values`` () =
 
     (* Numeric *)
 
-    Json.deserialize (Number 42.) =? decimal 42
-    Json.deserialize (Number 42.) =? float 42
-    Json.deserialize (Number 42.) =? int 42
-    Json.deserialize (Number 42.) =? int16 42
-    Json.deserialize (Number 42.) =? int64 42
-    Json.deserialize (Number 42.) =? single 42
-    Json.deserialize (Number 42.) =? uint16 42
-    Json.deserialize (Number 42.) =? uint32 42
-    Json.deserialize (Number 42.) =? uint64 42
+    Json.deserialize (Number 42M) =? decimal 42
+    Json.deserialize (Number 42M) =? float 42
+    Json.deserialize (Number 42M) =? int 42
+    Json.deserialize (Number 42M) =? int16 42
+    Json.deserialize (Number 42M) =? int64 42
+    Json.deserialize (Number 42M) =? single 42
+    Json.deserialize (Number 42M) =? uint16 42
+    Json.deserialize (Number 42M) =? uint32 42
+    Json.deserialize (Number 42M) =? uint64 42
 
     (* String *)
 
@@ -174,8 +174,8 @@ let ``Json.deserialize complex types returns correct values`` () =
 
     Json.deserialize (
         Object (Map.ofList
-            [ "one", Number 1.
-              "two", Number 2. ]))
+            [ "one", Number 1M
+              "two", Number 2M ]))
         =? Map.ofList [ "one", 1; "two", 2 ]
 
     (* Sets *)
@@ -190,7 +190,7 @@ let ``Json.deserialize complex types returns correct values`` () =
 
     (* Tuples *)
 
-    Json.deserialize (Array [ String "hello"; Number 42. ])
+    Json.deserialize (Array [ String "hello"; Number 42M ])
         =? ("hello", 42)
 
 type Test =
@@ -215,7 +215,7 @@ type Test =
 let testJson =
     Object (Map.ofList
         [ "string", String "hello"
-          "number", Number 42.
+          "number", Number 42M
           "values", Array [ Bool true; Bool false ] ])
 
 let testInstance =
@@ -236,15 +236,15 @@ let ``Json.serialize with simple types returns correct values`` () =
 
     (* Numeric *)
 
-    Json.serialize (decimal 42) =? Number 42.
-    Json.serialize (float 42) =? Number 42.
-    Json.serialize (int 42) =? Number 42.
-    Json.serialize (int16 42) =? Number 42.
-    Json.serialize (int64 42) =? Number 42.
-    Json.serialize (single 42) =? Number 42.
-    Json.serialize (uint16 42) =? Number 42.
-    Json.serialize (uint32 42) =? Number 42.
-    Json.serialize (uint64 42) =? Number 42.
+    Json.serialize (decimal 42) =? Number 42M
+    Json.serialize (float 42) =? Number 42M
+    Json.serialize (int 42) =? Number 42M
+    Json.serialize (int16 42) =? Number 42M
+    Json.serialize (int64 42) =? Number 42M
+    Json.serialize (single 42) =? Number 42M
+    Json.serialize (uint16 42) =? Number 42M
+    Json.serialize (uint32 42) =? Number 42M
+    Json.serialize (uint64 42) =? Number 42M
 
     (* DateTime *)
 
@@ -282,7 +282,7 @@ let testUnion =
 
 let testUnionJson =
     Object (Map.ofList
-        [ "two", Array [ Number 42.; Bool true ] ])
+        [ "two", Array [ Number 42M; Bool true ] ])
 
 [<Test>]
 let ``Json.serialize with union types remains tractable`` () =


### PR DESCRIPTION
...terests of preserving accuracy and the likely uses cases of interchange being more suited to decimal representation.