### PR TITLE
Add writeUnlessDefault function

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -898,6 +898,11 @@ module Mapping =
         let inline write key value =
             Json.setLensPartial (Json.ObjectPLens >??> mapPLens key) (toJson value)
 
+        let inline writeUnlessDefault key def value =
+            match value with
+            | v when v = def -> Json.ofResult <| Value ()
+            | _ -> write key value
+
         (* Serialization/Deserialization *)
 
         let inline deserialize json =

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -60,9 +60,9 @@ let ``Json.map2 returns correct values`` () =
    data structures. *)
 
 let private lens =
-         idLens 
-    <-?> Json.ObjectPIso 
-    >??> mapPLens "bool" 
+         idLens
+    <-?> Json.ObjectPIso
+    >??> mapPLens "bool"
     <??> Json.BoolPIso
 
 [<Test>]
@@ -206,13 +206,13 @@ type Test =
                   Values = v
                   Json = j }
         <!> Json.read "string"
-        <*> Json.read "number"
+        <*> Json.readOrDefault "number" None
         <*> Json.read "values"
         <*> Json.read "json"
 
     static member ToJson (x: Test) =
             Json.write "string" x.String
-         *> Json.write "number" x.Number
+         *> Json.writeUnlessDefault "number" None x.Number
          *> Json.write "values" x.Values
          *> Json.write "json" x.Json
 
@@ -232,6 +232,37 @@ let testInstance =
 [<Test>]
 let ``Json.deserialize with custom typed returns correct values`` () =
     Json.deserialize testJson =? testInstance
+
+let testJsonWithNullOption =
+    Object (Map.ofList
+        [ "string", String "hello"
+          "number", Null ()
+          "values", Array []
+          "json", Object (Map [ "hello", String "world" ]) ])
+
+let testInstanceWithNoneOption =
+    { String = "hello"
+      Number = None
+      Values = [ ]
+      Json = Object (Map [ "hello", String "world" ]) }
+
+[<Test>]
+let ``Json.deserialize with null option value`` () =
+    Json.deserialize testJsonWithNullOption =? testInstanceWithNoneOption
+
+let testJsonWithMissingOption =
+    Object (Map.ofList
+        [ "string", String "hello"
+          "values", Array []
+          "json", Object (Map [ "hello", String "world" ]) ])
+
+[<Test>]
+let ``Json.deserialize with missing value`` () =
+    Json.deserialize testJsonWithMissingOption =? testInstanceWithNoneOption
+
+[<Test>]
+let ``Json.serialize with default value`` () =
+    Json.serialize testInstanceWithNoneOption =? testJsonWithMissingOption
 
 [<Test>]
 let ``Json.serialize with simple types returns correct values`` () =


### PR DESCRIPTION
There are times, especially with option types, where it is nice to be able to omit default values (that would otherwise be output as `null`). `Json.writeUnlessDefault` provides a nice complimentary function to `Json.readOrDefault`, which can be used to provide a default value if the expected value is omitted.

Tests included.