### PR TITLE
Add custom read write functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Paket
 .paket/paket.exe
 
+# Fake
+.fake/
+
 # Temp
 temp
 

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -884,30 +884,45 @@ module Mapping =
 
         (* Read/Write *)
 
-        let inline read key =
+        let inline readWith fromJson key =
                 fromJson >> Json.ofResult
             =<< Json.getLensPartial (Json.Object_ >??> key_ key)
 
-        let inline readOrDefault key def =
+        let inline read key =
+            readWith fromJson key
+
+        let inline readWithOrDefault fromJson key def =
                 function | Some json -> Json.ofResult (fromJson json)
                          | _ -> Json.init def
             =<< Json.tryGetLensPartial (Json.Object_ >??> key_ key)
 
-        let inline tryRead key =
+        let inline readOrDefault key def =
+            readWithOrDefault fromJson key def
+
+        let inline tryReadWith fromJson key =
                 function | Some json -> Some <!> Json.ofResult (fromJson json)
                          | _ -> Json.init None
             =<< Json.tryGetLensPartial (Json.Object_ >??> key_ key)
 
-        let inline write key value =
+        let inline tryRead key =
+            tryReadWith fromJson key
+
+        let inline writeWith toJson key value =
             Json.setLensPartial (Json.Object_ >??> key_ key) (toJson value)
+
+        let inline write key value =
+            writeWith toJson key value
+
+        let inline writeWithUnlessDefault toJson key def value =
+            match value with
+            | v when v = def -> Json.ofResult <| Value ()
+            | _ -> writeWith toJson key value
+
+        let inline writeUnlessDefault key def value =
+            writeWithUnlessDefault toJson key def value
 
         let inline writeNone key =
             Json.setLensPartial (Json.Object_ >??> key_ key) (Json.Null ())
-
-        let inline writeUnlessDefault key def value =
-            match value with
-            | v when v = def -> Json.ofResult <| Value ()
-            | _ -> write key value
 
         (* Serialization/Deserialization *)
 


### PR DESCRIPTION
Sometimes there is a need to serialize or deserialize values for types that were not created within the same assembly. Extension methods don't work to add `ToJson` or `FromJson` methods to these types. In this PR, I use `System.DayOfWeek` as the exemplar, but I plan to use it for serializing types from the `NodaTime` library. The key change here is to expose the `Json -> JsonResult<'a>` and `'a -> Json` shaped holes in the read/write functions.

Let me know what you think.