### PR TITLE
Better error messages for missing JSON Object members

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -644,7 +644,7 @@ module Formatting =
 
       static member SingleLine =
         { Spacing = append " "
-          NewLine = fun _ x -> x }
+          NewLine = fun _ -> append " " }
 
       static member Pretty =
         { Spacing = append " "

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -263,6 +263,22 @@ let ``Json.deserialize with missing value`` () =
 let ``Json.serialize with default value`` () =
     Json.serialize testInstanceWithNoneOption =! testJsonWithMissingOption
 
+let testJsonWithNoValues =
+    Object (Map.ofList
+        [ "string", String "hello"
+          "number", Number 42M
+          "json", Object (Map [ "hello", String "world" ]) ])
+
+[<Test>]
+let ``Json.deserialize with invalid value includes missing member name in quotes`` () =
+    let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
+    test <@ match result with Choice2Of2 e -> e.Contains("'values'") @>
+
+[<Test>]
+let ``Json.deserialize with invalid value includes JSON formatted object`` () =
+    let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
+    test <@ match result with Choice2Of2 e -> e.EndsWith(Json.formatWith JsonFormattingOptions.SingleLine testJsonWithNoValues) @>
+
 [<Test>]
 let ``Json.serialize with simple types returns correct values`` () =
 


### PR DESCRIPTION
Bask in the glory of error messages like:
```
"Error deserializing JSON object; Missing required member 'values': { "json": { "hello": "world" }, "number": 42, "string": "hello" }"
```
Instead of:
```
"Couldn't use Prism (<fun:op_GreaterQmarkGreater@190-4>, <fun:op_GreaterQmarkGreater@191-5>) on JSON: 'Object
  (map
     [("json", Object (map [("hello", String "world")])); ("number", Number 42M);
      ("string", String "hello")])'"
```