### PR TITLE
Convert to xunit

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -19,3 +19,4 @@ group Test
   nuget NUnit
   nuget NUnit.Runners
   nuget Unquote
+  nuget xunit

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,22 +1,17 @@
 source http://nuget.org/api/v2
-
 nuget Aether 8.0.0-rc2
 nuget FParsec
 
 group Build
-
-  source http://nuget.org/api/v2
-
-  nuget Fake
+source http://nuget.org/api/v2
+nuget Fake
 
 group Test
-
-  framework: >= net45
-  source http://nuget.org/api/v2
-
-  nuget FSharp.Core 3.1.2.5 redirects: on
-  nuget FsCheck
-  nuget NUnit
-  nuget NUnit.Runners
-  nuget Unquote
-  nuget xunit
+framework: >= net45
+source http://nuget.org/api/v2
+nuget FsCheck.Xunit
+nuget FSharp.Core 3.1.2.5 redirects: on
+nuget FsCheck
+nuget Unquote
+nuget xunit
+nuget xunit.runner.console

--- a/paket.lock
+++ b/paket.lock
@@ -17,129 +17,21 @@ NUGET
   specs:
     FsCheck (2.2.1)
       FSharp.Core (>= 3.1.2.5)
+    FsCheck.Xunit (2.2.1)
+      FsCheck (>= 2.2.1)
+      xunit.extensibility.execution (>= 2.1.0 < 2.2.0)
     FSharp.Core (3.1.2.5) - redirects: on
-    NUnit (2.6.4)
-    NUnit.Runners (2.6.4)
-    System.Collections (4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Threading (>= 4.0.0) - framework: dnxcore50
-    System.Diagnostics.Contracts (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-    System.Diagnostics.Debug (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-    System.Globalization (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-    System.IO (4.0.10) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Text.Encoding (>= 4.0.0) - framework: dnxcore50
-      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
-      System.Text.Encoding.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Threading (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
-    System.Linq (4.0.0) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
-    System.ObjectModel (4.0.10) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Threading (>= 4.0.10) - framework: dnxcore50
-    System.Private.Uri (4.0.0) - framework: dnxcore50
-    System.Reflection (4.0.10) - framework: dnxcore50
-      System.IO (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-    System.Reflection.Extensions (4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.10) - framework: dnxcore50
-      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.TypeExtensions (>= 4.0.0) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
-    System.Reflection.Primitives (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Threading (>= 4.0.0) - framework: dnxcore50
-    System.Reflection.TypeExtensions (4.0.0) - framework: dnxcore50
-      System.Diagnostics.Contracts (>= 4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
-      System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.10) - framework: dnxcore50
-      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
-    System.Resources.ResourceManager (4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-    System.Runtime (4.0.20) - framework: dnxcore50
-      System.Private.Uri (>= 4.0.0) - framework: dnxcore50
-    System.Runtime.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-    System.Text.Encoding (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-    System.Text.Encoding.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
-    System.Text.RegularExpressions (4.0.10) - framework: dnxcore50
-      System.Collections (>= 4.0.10) - framework: dnxcore50
-      System.Globalization (>= 4.0.10) - framework: dnxcore50
-      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.20) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
-      System.Threading (>= 4.0.10) - framework: dnxcore50
-    System.Threading (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
-    System.Threading.Tasks (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
     Unquote (3.1.0)
     xunit (2.1.0)
       xunit.assert (2.1.0)
       xunit.core (2.1.0)
-    xunit.abstractions (2.0.0) - framework: dnxcore50
+    xunit.abstractions (2.0.0)
     xunit.assert (2.1.0)
-      System.Collections (>= 4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.ObjectModel (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Text.RegularExpressions (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
     xunit.core (2.1.0)
-      System.Collections (>= 4.0.0) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0) - framework: dnxcore50
-      System.Linq (>= 4.0.0) - framework: dnxcore50
-      System.Reflection (>= 4.0.0) - framework: dnxcore50
-      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0) - framework: dnxcore50
-      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
-      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
-      xunit.abstractions (>= 2.0.0) - framework: dnxcore50
-      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-      xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-    xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.extensibility.core (2.1.0)
+      xunit.extensibility.execution (2.1.0)
+    xunit.extensibility.core (2.1.0)
       xunit.abstractions (2.0.0)
-    xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
-      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, >= net45
+    xunit.extensibility.execution (2.1.0)
+      xunit.extensibility.core (2.1.0)
+    xunit.runner.console (2.1.0)

--- a/paket.lock
+++ b/paket.lock
@@ -20,4 +20,126 @@ NUGET
     FSharp.Core (3.1.2.5) - redirects: on
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
+    System.Collections (4.0.10) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
+    System.Diagnostics.Contracts (4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+    System.Diagnostics.Debug (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+    System.Globalization (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+    System.IO (4.0.10) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.0) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
+      System.Text.Encoding.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+    System.Linq (4.0.0) - framework: dnxcore50
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+    System.ObjectModel (4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Threading (>= 4.0.10) - framework: dnxcore50
+    System.Private.Uri (4.0.0) - framework: dnxcore50
+    System.Reflection (4.0.10) - framework: dnxcore50
+      System.IO (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+    System.Reflection.Extensions (4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.TypeExtensions (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+    System.Reflection.Primitives (4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
+    System.Reflection.TypeExtensions (4.0.0) - framework: dnxcore50
+      System.Diagnostics.Contracts (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+    System.Resources.ResourceManager (4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+    System.Runtime (4.0.20) - framework: dnxcore50
+      System.Private.Uri (>= 4.0.0) - framework: dnxcore50
+    System.Runtime.Extensions (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+    System.Text.Encoding (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+    System.Text.Encoding.Extensions (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
+    System.Text.RegularExpressions (4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Globalization (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+      System.Threading (>= 4.0.10) - framework: dnxcore50
+    System.Threading (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+    System.Threading.Tasks (4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     Unquote (3.1.0)
+    xunit (2.1.0)
+      xunit.assert (2.1.0)
+      xunit.core (2.1.0)
+    xunit.abstractions (2.0.0) - framework: dnxcore50
+    xunit.assert (2.1.0)
+      System.Collections (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.ObjectModel (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Text.RegularExpressions (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+    xunit.core (2.1.0)
+      System.Collections (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+      xunit.abstractions (>= 2.0.0) - framework: dnxcore50
+      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+    xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.abstractions (2.0.0)
+    xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, >= net45

--- a/tests/Chiron.Tests/App.config
+++ b/tests/Chiron.Tests/App.config
@@ -9,4 +9,7 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
 </configuration>

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -1,9 +1,11 @@
 ﻿module Chiron.Tests.Properties
 
 open Chiron
+open Xunit
 open FsCheck
-open NUnit.Framework
+open FsCheck.Xunit
 open Chiron.Operators
+open Swensen.Unquote
 
 type TestRecord =
     { StringField: string
@@ -47,7 +49,6 @@ type Overrides =
         Arb.Default.DateTime ()
         |> Arb.mapFilter (fun dt -> dt.ToUniversalTime()) (fun dt -> dt.Kind = System.DateTimeKind.Utc)
 
-[<Test>]
 let ``Chiron properties`` () =
     let config = { Config.VerboseThrowOnFailure with
                       Arbitrary = [ typeof<Overrides> ] }

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -116,7 +116,7 @@ let rec ``Arbitrary Json doesn't have null strings`` (v : Json) =
     | _ -> true
 
 [<Arbitrary(typeof<Arbitrary>)>]
-module Primitives =
+module MappingDefaults =
     [<Property>]
     let ``Non-null strings can be round-tripped`` (NonNull str) =
         doRoundTripTest str

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -149,11 +149,11 @@ module MappingDefaults =
     let ``uint64 can be round-tripped`` (v : uint64) =
         doRoundTripTest v
 
-    [<Property>]
+    [<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
     let ``Normal single can be round-tripped`` (NormalSingle v) =
         doRoundTripTest v
 
-    [<Property>]
+    [<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
     let ``Normal float can be round-tripped`` (NormalFloat v) =
         doRoundTripTest v
 

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -29,6 +29,162 @@ let inline roundTrip (thing : 'a) : 'a =
     |> Json.parse
     |> Json.deserialize
 
+let inline doRoundTripTest v =
+    let serialize,deserialize = Json.serialize, Json.deserialize
+    test <@ v |> serialize |> Json.format |> Json.parse |> deserialize = v @>
+
+let always x = fun _ -> x
+let pair a b = a,b
+
+type NormalSingle = NormalSingle of single with
+    member x.Get = match x with NormalSingle v -> x
+    override x.ToString () = x.Get.ToString()
+
+type Arbitrary = Arbitrary with
+    static member NormalSingle () : Arbitrary<NormalSingle> =
+        Arb.from<single>
+        |> Arb.filter (fun f -> not (System.Single.IsNaN f || System.Single.IsInfinity f))
+        |> Arb.convert NormalSingle (fun (NormalSingle v) -> v)
+
+    static member Json () : Arbitrary<Json> =
+        let genNull = Null () |> Gen.constant
+        let genNonNullString = Arb.generate<NonNull<string>> |> Gen.map (fun nes -> nes.Get)
+        let genJsonString = genNonNullString |> Gen.map String
+        let genJsonNumber = Arb.generate<decimal> |> Gen.map Number
+        let genJsonBool = Arb.generate<bool> |> Gen.map Bool
+        let genJsonArray size innerGen = Gen.listOfLength size innerGen |> Gen.map Array
+        let genJsonObject size innerGen = Gen.map2 pair genNonNullString innerGen |> Gen.listOfLength size |> Gen.map (Map.ofList >> Object)
+
+        let sqrtSize = float >> sqrt >> int
+
+        let rec generateSized maxdepth depth =
+            fun size -> gen {
+              let nextSize = size - 1
+              return!
+                  Gen.frequency
+                      [ 1, genNull
+                        1, genJsonBool
+                        2, genJsonString
+                        2, genJsonNumber
+                        ((float (maxdepth - depth) / float maxdepth) * 4. |> ceil |> int), genJsonArray size (generateSized maxdepth (depth + 1) nextSize)
+                        ((float (maxdepth - depth) / float maxdepth) * 8. |> ceil |> int), genJsonObject size (generateSized maxdepth (depth + 1) nextSize) ]
+            }
+
+        let inline ifFullyShrunkThen v shrinkAlt map =
+            let shrunk = Arb.shrink v
+            if Seq.isEmpty shrunk then
+                shrinkAlt
+            else
+                (shrunk |> Seq.map map)
+
+        let shrinkToNull = Seq.singleton (Null ())
+        let shrinkToBool = Seq.ofList [ Bool true; Bool false ]
+        let numberOrString = Seq.ofList [ Number 0M; String "" ]
+
+        let shrink = function
+            | Null () -> Seq.empty
+            | Bool b -> ifFullyShrunkThen b shrinkToNull Bool
+            | String s -> ifFullyShrunkThen s shrinkToBool String
+            | Number n -> ifFullyShrunkThen n shrinkToBool Number
+            | Array a -> ifFullyShrunkThen a numberOrString Array
+            | Object o -> ifFullyShrunkThen o numberOrString Object
+
+        let getDepthLimit = float >> (fun f -> System.Math.Log (f,2.)) >> int
+
+        let gen = Gen.sized <| fun size -> let depthLimit = getDepthLimit size in generateSized (depthLimit + 1) 0 (sqrtSize size)
+
+        Arb.fromGenShrink (gen,shrink)
+
+[<Fact>]
+let ``Custom arbitrary Json generates sufficiently arbitrary Json`` () =
+    let ``Is not an object with a member array containing a fourth item which is a String`` (v : Json) =
+        match v with
+        | Object m -> Map.exists (fun _ v -> (match v with Array (_::_::_::(String _)::_::_) -> true | _ -> false)) m |> not
+        | _ -> true
+    raises
+        <@ Check.One
+          ( { Config.VerboseThrowOnFailure with MaxTest=1000; Arbitrary=typeof<Arbitrary> :: Config.Default.Arbitrary },
+            ``Is not an object with a member array containing a fourth item which is a String``) @>
+
+[<Property(Arbitrary=[|typeof<Arbitrary>|])>]
+let rec ``Arbitrary Json doesn't have null strings`` (v : Json) =
+    match v with
+    | String null -> false
+    | Array a -> List.forall ``Arbitrary Json doesn't have null strings`` a
+    | Object o -> Map.forall (fun k v -> k <> null && ``Arbitrary Json doesn't have null strings`` v) o
+    | _ -> true
+
+[<Arbitrary(typeof<Arbitrary>)>]
+module Primitives =
+    [<Property>]
+    let ``Non-null strings can be round-tripped`` (NonNull str) =
+        doRoundTripTest str
+
+    [<Property>]
+    let ``Guid can be round-tripped`` (v : System.Guid) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``int16 can be round-tripped`` (v : int16) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``uint16 can be round-tripped`` (v : uint16) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``int can be round-tripped`` (v : int) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``uint32 can be round-tripped`` (v : uint32) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``int64 can be round-tripped`` (v : int64) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``uint64 can be round-tripped`` (v : uint64) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``Normal single can be round-tripped`` (NormalSingle v) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``Normal float can be round-tripped`` (NormalFloat v) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``decimal can be round-tripped`` (v : decimal) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``bool can be round-tripped`` (v : bool) =
+        doRoundTripTest v
+
+//    [<Property>]
+//    let ``byte can be round-tripped`` (v : byte) =
+//        doRoundTripTest v
+
+//    [<Property>]
+//    let ``sbyte can be round-tripped`` (v : sbyte) =
+//        doRoundTripTest v
+
+    [<Property>]
+    let ``DateTime can be round-tripped`` (v : System.DateTime) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``DateTimeOffset can be round-tripped`` (v : System.DateTimeOffset) =
+        doRoundTripTest v
+
+    [<Property>]
+    let ``Json can be round-tripped`` (v : Json) =
+        doRoundTripTest v
+
+
 type ChironProperties =
     static member ``Strings can be roundtripped`` (str : string) =
         let sut = roundTrip str

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -97,7 +97,7 @@ type Arbitrary = Arbitrary with
             | Array a -> ifFullyShrunkThen a numberOrString Array
             | Object o -> ifFullyShrunkThen o numberOrString Object
 
-        let getDepthLimit = float >> (fun f -> System.Math.Log (f,2.)) >> int
+        let getDepthLimit = float >> (fun f -> System.Math.Log (f,3.)) >> int
 
         let gen = Gen.sized <| fun size -> let depthLimit = getDepthLimit size in generateSized (depthLimit + 1) 0 (sqrtSize size)
 

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -37,11 +37,11 @@ let always x = fun _ -> x
 let pair a b = a,b
 
 type NormalSingle = NormalSingle of single with
-    member x.Get = match x with NormalSingle v -> x
+    member x.Get = match x with NormalSingle v -> v
     override x.ToString () = x.Get.ToString()
 
 type UtcDateTime = UtcDateTime of System.DateTime with
-    member x.Get = match x with UtcDateTime v -> x
+    member x.Get = match x with UtcDateTime v -> v
     override x.ToString () = x.Get.ToString()
 
 type Arbitrary = Arbitrary with

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -1,11 +1,13 @@
-﻿module Chiron.Tests.Properties
+﻿[<FsCheck.Xunit.Arbitrary(typeof<Chiron.Testing.Arbitrary>)>]
+module Chiron.Tests.Properties
 
-open Chiron
 open Xunit
 open FsCheck
 open FsCheck.Xunit
-open Chiron.Operators
 open Swensen.Unquote
+open Chiron
+open Chiron.Operators
+open Chiron.Testing
 
 type TestRecord =
     { StringField: string
@@ -27,165 +29,75 @@ let inline doRoundTripTest v =
     let serialize,deserialize = Json.serialize, Json.deserialize
     test <@ v |> serialize |> Json.format |> Json.parse |> deserialize = v @>
 
-let pair a b = a,b
+[<Property>]
+let ``Non-null strings can be round-tripped`` (NonNull str) =
+    doRoundTripTest str
 
-type NormalSingle = NormalSingle of single with
-    member x.Get = match x with NormalSingle v -> v
-    override x.ToString () = x.Get.ToString()
+[<Property>]
+let ``Guid can be round-tripped`` (v : System.Guid) =
+    doRoundTripTest v
 
-type UtcDateTime = UtcDateTime of System.DateTime with
-    member x.Get = match x with UtcDateTime v -> v
-    override x.ToString () = x.Get.ToString()
+[<Property>]
+let ``int16 can be round-tripped`` (v : int16) =
+    doRoundTripTest v
 
-type Arbitrary = Arbitrary with
-    static member NormalSingle () : Arbitrary<NormalSingle> =
-        Arb.from<single>
-        |> Arb.filter (fun f -> not (System.Single.IsNaN f || System.Single.IsInfinity f))
-        |> Arb.convert NormalSingle (fun (NormalSingle v) -> v)
+[<Property>]
+let ``uint16 can be round-tripped`` (v : uint16) =
+    doRoundTripTest v
 
-    static member UtcDateTime () : Arbitrary<UtcDateTime> =
-        Arb.from<System.DateTime>
-        |> Arb.convert (fun dt -> dt.ToUniversalTime() |> UtcDateTime) (fun (UtcDateTime dt) -> dt)
+[<Property>]
+let ``int can be round-tripped`` (v : int) =
+    doRoundTripTest v
 
-    static member Json () : Arbitrary<Json> =
-        let genNull = Null () |> Gen.constant
-        let genNonNullString = Arb.generate<NonNull<string>> |> Gen.map (fun nes -> nes.Get)
-        let genJsonString = genNonNullString |> Gen.map String
-        let genJsonNumber = Arb.generate<decimal> |> Gen.map Number
-        let genJsonBool = Arb.generate<bool> |> Gen.map Bool
-        let genJsonArray size innerGen = Gen.listOfLength size innerGen |> Gen.map Array
-        let genJsonObject size innerGen = Gen.map2 pair genNonNullString innerGen |> Gen.listOfLength size |> Gen.map (Map.ofList >> Object)
+[<Property>]
+let ``uint32 can be round-tripped`` (v : uint32) =
+    doRoundTripTest v
 
-        let sqrtSize = float >> sqrt >> int
+[<Property>]
+let ``int64 can be round-tripped`` (v : int64) =
+    doRoundTripTest v
 
-        let rec generateSized maxdepth depth =
-            fun size -> gen {
-              let nextSize = size - 1
-              return!
-                  Gen.frequency
-                      [ 1, genNull
-                        1, genJsonBool
-                        2, genJsonString
-                        2, genJsonNumber
-                        ((float (maxdepth - depth) / float maxdepth) * 4. |> ceil |> int), genJsonArray size (generateSized maxdepth (depth + 1) nextSize)
-                        ((float (maxdepth - depth) / float maxdepth) * 8. |> ceil |> int), genJsonObject size (generateSized maxdepth (depth + 1) nextSize) ]
-            }
+[<Property>]
+let ``uint64 can be round-tripped`` (v : uint64) =
+    doRoundTripTest v
 
-        let inline ifFullyShrunkThen v shrinkAlt map =
-            let shrunk = Arb.shrink v
-            if Seq.isEmpty shrunk then
-                shrinkAlt
-            else
-                (shrunk |> Seq.map map)
+[<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
+let ``Normal single can be round-tripped`` (NormalSingle v) =
+    doRoundTripTest v
 
-        let shrinkToNull = Seq.singleton (Null ())
-        let shrinkToBool = Seq.ofList [ Bool true; Bool false ]
-        let numberOrString = Seq.ofList [ Number 0M; String "" ]
+[<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
+let ``Normal float can be round-tripped`` (NormalFloat v) =
+    doRoundTripTest v
 
-        let shrink = function
-            | Null () -> Seq.empty
-            | Bool b -> ifFullyShrunkThen b shrinkToNull Bool
-            | String s -> ifFullyShrunkThen s shrinkToBool String
-            | Number n -> ifFullyShrunkThen n shrinkToBool Number
-            | Array a -> ifFullyShrunkThen a numberOrString Array
-            | Object o -> ifFullyShrunkThen o numberOrString Object
+[<Property>]
+let ``decimal can be round-tripped`` (v : decimal) =
+    doRoundTripTest v
 
-        let getDepthLimit = float >> (fun f -> System.Math.Log (f,3.)) >> int
+[<Property>]
+let ``bool can be round-tripped`` (v : bool) =
+    doRoundTripTest v
 
-        let gen = Gen.sized <| fun size -> let depthLimit = getDepthLimit size in generateSized (depthLimit + 1) 0 (sqrtSize size)
+//[<Property>]
+//let ``byte can be round-tripped`` (v : byte) =
+//    doRoundTripTest v
 
-        Arb.fromGenShrink (gen,shrink)
+//[<Property>]
+//let ``sbyte can be round-tripped`` (v : sbyte) =
+//    doRoundTripTest v
 
-[<Fact>]
-let ``Custom arbitrary Json generates sufficiently arbitrary Json`` () =
-    let ``Is not an object with a member array containing a fourth item which is a String`` (v : Json) =
-        match v with
-        | Object m -> Map.exists (fun _ v -> (match v with Array (_::_::_::(String _)::_::_) -> true | _ -> false)) m |> not
-        | _ -> true
-    raises
-        <@ Check.One
-          ( { Config.VerboseThrowOnFailure with MaxTest=1000; Arbitrary=typeof<Arbitrary> :: Config.Default.Arbitrary },
-            ``Is not an object with a member array containing a fourth item which is a String``) @>
+[<Property>]
+let ``UTC DateTime can be round-tripped`` (UtcDateTime v) =
+    doRoundTripTest v
 
-[<Property(Arbitrary=[|typeof<Arbitrary>|])>]
-let rec ``Arbitrary Json doesn't have null strings`` (v : Json) =
-    match v with
-    | String null -> false
-    | Array a -> List.forall ``Arbitrary Json doesn't have null strings`` a
-    | Object o -> Map.forall (fun k v -> k <> null && ``Arbitrary Json doesn't have null strings`` v) o
-    | _ -> true
+[<Property>]
+let ``Deserialized DateTimes are UTC`` (v : System.DateTime) =
+    let serialize, deserialize = Json.serialize, Json.deserialize
+    test <@ (v |> serialize |> Json.format |> Json.parse |> deserialize : System.DateTime).Kind = System.DateTimeKind.Utc @>
 
-[<Arbitrary(typeof<Arbitrary>)>]
-module MappingDefaults =
-    [<Property>]
-    let ``Non-null strings can be round-tripped`` (NonNull str) =
-        doRoundTripTest str
+[<Property>]
+let ``DateTimeOffset can be round-tripped`` (v : System.DateTimeOffset) =
+    doRoundTripTest v
 
-    [<Property>]
-    let ``Guid can be round-tripped`` (v : System.Guid) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``int16 can be round-tripped`` (v : int16) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``uint16 can be round-tripped`` (v : uint16) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``int can be round-tripped`` (v : int) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``uint32 can be round-tripped`` (v : uint32) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``int64 can be round-tripped`` (v : int64) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``uint64 can be round-tripped`` (v : uint64) =
-        doRoundTripTest v
-
-    [<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
-    let ``Normal single can be round-tripped`` (NormalSingle v) =
-        doRoundTripTest v
-
-    [<Property(Skip="Handling of floating point values is known to fail to round-trip")>]
-    let ``Normal float can be round-tripped`` (NormalFloat v) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``decimal can be round-tripped`` (v : decimal) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``bool can be round-tripped`` (v : bool) =
-        doRoundTripTest v
-
-//    [<Property>]
-//    let ``byte can be round-tripped`` (v : byte) =
-//        doRoundTripTest v
-
-//    [<Property>]
-//    let ``sbyte can be round-tripped`` (v : sbyte) =
-//        doRoundTripTest v
-
-    [<Property>]
-    let ``UTC DateTime can be round-tripped`` (UtcDateTime v) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``Deserialized DateTimes are UTC`` (v : System.DateTime) =
-        let serialize, deserialize = Json.serialize, Json.deserialize
-        test <@ (v |> serialize |> Json.format |> Json.parse |> deserialize : System.DateTime).Kind = System.DateTimeKind.Utc @>
-
-    [<Property>]
-    let ``DateTimeOffset can be round-tripped`` (v : System.DateTimeOffset) =
-        doRoundTripTest v
-
-    [<Property>]
-    let ``Json can be round-tripped`` (v : Json) =
-        doRoundTripTest v
+[<Property>]
+let ``Json can be round-tripped`` (v : Json) =
+    doRoundTripTest v

--- a/tests/Chiron.Tests/Chiron.Testing.fs
+++ b/tests/Chiron.Tests/Chiron.Testing.fs
@@ -1,0 +1,96 @@
+﻿module Chiron.Testing
+
+open FsCheck
+open Chiron
+
+let inline private pair a b = a,b
+
+type NormalSingle = NormalSingle of single with
+    member x.Get = match x with NormalSingle v -> v
+    override x.ToString () = x.Get.ToString()
+
+type UtcDateTime = UtcDateTime of System.DateTime with
+    member x.Get = match x with UtcDateTime v -> v
+    override x.ToString () = x.Get.ToString()
+
+type Arbitrary = Arbitrary with
+    static member NormalSingle () : Arbitrary<NormalSingle> =
+        Arb.from<single>
+        |> Arb.filter (fun f -> not (System.Single.IsNaN f || System.Single.IsInfinity f))
+        |> Arb.convert NormalSingle (fun (NormalSingle v) -> v)
+
+    static member UtcDateTime () : Arbitrary<UtcDateTime> =
+        Arb.from<System.DateTime>
+        |> Arb.convert (fun dt -> dt.ToUniversalTime() |> UtcDateTime) (fun (UtcDateTime dt) -> dt)
+
+    static member Json () : Arbitrary<Json> =
+        let genNull = Null () |> Gen.constant
+        let genNonNullString = Arb.generate<NonNull<string>> |> Gen.map (fun nes -> nes.Get)
+        let genJsonString = genNonNullString |> Gen.map String
+        let genJsonNumber = Arb.generate<decimal> |> Gen.map Number
+        let genJsonBool = Arb.generate<bool> |> Gen.map Bool
+        let genJsonArray size innerGen = Gen.listOfLength size innerGen |> Gen.map Array
+        let genJsonObject size innerGen = Gen.map2 pair genNonNullString innerGen |> Gen.listOfLength size |> Gen.map (Map.ofList >> Object)
+
+        let sqrtSize = float >> sqrt >> int
+
+        let rec generateSized maxdepth depth =
+            fun size -> gen {
+              let nextSize = size - 1
+              return!
+                  Gen.frequency
+                      [ 1, genNull
+                        1, genJsonBool
+                        2, genJsonString
+                        2, genJsonNumber
+                        ((float (maxdepth - depth) / float maxdepth) * 4. |> ceil |> int), genJsonArray size (generateSized maxdepth (depth + 1) nextSize)
+                        ((float (maxdepth - depth) / float maxdepth) * 8. |> ceil |> int), genJsonObject size (generateSized maxdepth (depth + 1) nextSize) ]
+            }
+
+        let inline ifFullyShrunkThen v shrinkAlt map =
+            let shrunk = Arb.shrink v
+            if Seq.isEmpty shrunk then
+                shrinkAlt
+            else
+                (shrunk |> Seq.map map)
+
+        let shrinkToNull = Seq.singleton (Null ())
+        let shrinkToBool = Seq.ofList [ Bool true; Bool false ]
+        let numberOrString = Seq.ofList [ Number 0M; String "" ]
+
+        let shrink = function
+            | Null () -> Seq.empty
+            | Bool b -> ifFullyShrunkThen b shrinkToNull Bool
+            | String s -> ifFullyShrunkThen s shrinkToBool String
+            | Number n -> ifFullyShrunkThen n shrinkToBool Number
+            | Array a -> ifFullyShrunkThen a numberOrString Array
+            | Object o -> ifFullyShrunkThen o numberOrString Object
+
+        let getDepthLimit = float >> (fun f -> System.Math.Log (f,3.)) >> int
+
+        let gen = Gen.sized <| fun size -> let depthLimit = getDepthLimit size in generateSized (depthLimit + 1) 0 (sqrtSize size)
+
+        Arb.fromGenShrink (gen,shrink)
+
+module SelfTest =
+    open FsCheck.Xunit
+    open Swensen.Unquote
+
+    [<Xunit.Fact>]
+    let ``Custom arbitrary Json generates sufficiently arbitrary Json`` () =
+        let ``Is not an object with a member array containing a fourth item which is a String`` (v : Json) =
+            match v with
+            | Object m -> Map.exists (fun _ v -> (match v with Array (_::_::_::(String _)::_::_) -> true | _ -> false)) m |> not
+            | _ -> true
+        raises
+            <@ Check.One
+              ( { Config.VerboseThrowOnFailure with MaxTest=1000; Arbitrary=typeof<Arbitrary> :: Config.Default.Arbitrary },
+                ``Is not an object with a member array containing a fourth item which is a String``) @>
+
+    [<Property(Arbitrary=[|typeof<Arbitrary>|])>]
+    let rec ``Arbitrary Json doesn't have null strings`` (v : Json) =
+        match v with
+        | String null -> false
+        | Array a -> List.forall ``Arbitrary Json doesn't have null strings`` a
+        | Object o -> Map.forall (fun k v -> k <> null && ``Arbitrary Json doesn't have null strings`` v) o
+        | _ -> true

--- a/tests/Chiron.Tests/Chiron.Testing.fs
+++ b/tests/Chiron.Tests/Chiron.Testing.fs
@@ -84,7 +84,7 @@ module SelfTest =
             | _ -> true
         raises
             <@ Check.One
-              ( { Config.VerboseThrowOnFailure with MaxTest=1000; Arbitrary=typeof<Arbitrary> :: Config.Default.Arbitrary },
+              ( { Config.QuickThrowOnFailure with MaxTest=1000; Arbitrary=typeof<Arbitrary> :: Config.Default.Arbitrary },
                 ``Is not an object with a member array containing a fourth item which is a String``) @>
 
     [<Property(Arbitrary=[|typeof<Arbitrary>|])>]

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -5,7 +5,7 @@ open Aether
 open Aether.Operators
 open Chiron
 open Chiron.Operators
-open NUnit.Framework
+open Xunit
 open Swensen.Unquote
 
 (* Cases *)
@@ -25,30 +25,30 @@ let private t2 =
    Tests to exercise the basic functional components of the Json<'a>
    type and combinators thereof. *)
 
-[<Test>]
+[<Fact>]
 let ``Json.init returns correct values`` () =
     Json.init 1 t1 =! (Value 1,  t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.error returns correct values`` () =
     Json.error "e" t1 =! (Error "e", t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.bind returns correct values`` () =
     Json.bind (Json.init 2) (fun x -> Json.init (x * 3)) t1 =! (Value 6, t1)
     Json.bind (Json.error "e") (fun x -> Json.init (x * 3)) t1 =! (Error "e", t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.apply returns correct values`` () =
     Json.apply (Json.init (fun x -> x * 3)) (Json.init 2) t1 =! (Value 6, t1)
     Json.apply (Json.init (fun x -> x * 3)) (Json.error "e") t1 =! (Error "e", t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.map returns correct values`` () =
     Json.map (fun x -> x * 3) (Json.init 2) t1 =! (Value 6, t1)
     Json.map (fun x -> x * 3) (Json.error "e") t1 =! (Error "e", t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.map2 returns correct values`` () =
     Json.map2 (*) (Json.init 2) (Json.init 3) t1 =! (Value 6, t1)
     Json.map2 (*) (Json.error "e") (Json.init 3) t1 =! (Error "e", t1)
@@ -64,37 +64,37 @@ let private prism_ =
     >?> Map.key_ "bool"
     >?> Json.Bool_
 
-[<Test>]
+[<Fact>]
 let ``Json.Lens.get returns correct values`` () =
     Json.Optic.get id_ t1 =! (Value t1, t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.get with Lens returns correct values`` () =
     Json.Optic.get prism_ t1 =! (Value true, t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.tryGet with Prism returns correct values`` () =
     Json.Optic.tryGet Json.Number_ t1 =! (Value None, t1)
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.set with Lens returns correct values`` () =
     Json.Optic.set id_ (Bool false) t1 =! (Value (), Bool false)
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.set with Prism returns correct values`` () =
     Json.Optic.set prism_ false t1 =! (Value (), t2)
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.map with Lens returns correct values`` () =
     Json.Optic.map id_ (fun _ -> Null ()) t1 =! (Value (), Null ())
 
-[<Test>]
+[<Fact>]
 let ``Json.Optic.map with Prism returns correct values`` () =
     Json.Optic.map prism_ not t1 =! (Value (), t2)
 
 (* Parsing *)
 
-[<Test>]
+[<Fact>]
 let ``Json.parse returns correct values`` () =
     Json.parse "\"hello\"" =! String "hello"
     Json.parse "\"\"" =! String ""
@@ -104,7 +104,7 @@ let ``Json.parse returns correct values`` () =
 
 (* Formatting *)
 
-[<Test>]
+[<Fact>]
 let ``Json.format returns correct values`` () =
     (* String *)
     Json.format <| String "hello" =! "\"hello\""
@@ -125,7 +125,7 @@ let ``Json.format returns correct values`` () =
    Tests exercising mapping functions between Json and other F#
    data structures. *)
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize simple types returns correct values`` () =
 
     (* Boolean *)
@@ -156,7 +156,7 @@ let ``Json.deserialize simple types returns correct values`` () =
 
     Json.deserialize (String "2015-04-15T13:45:55Z") =! DateTimeOffset (2015, 4, 15, 13, 45, 55, TimeSpan.Zero)
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize complex types returns correct values`` () =
 
     (* Arrays *)
@@ -228,7 +228,7 @@ let testInstance =
       Values = [ true; false ]
       Json = Object (Map [ "hello", String "world" ]) }
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with custom typed returns correct values`` () =
     Json.deserialize testJson =! testInstance
 
@@ -245,7 +245,7 @@ let testInstanceWithNoneOption =
       Values = [ ]
       Json = Object (Map [ "hello", String "world" ]) }
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with null option value`` () =
     Json.deserialize testJsonWithNullOption =! testInstanceWithNoneOption
 
@@ -255,11 +255,11 @@ let testJsonWithMissingOption =
           "values", Array []
           "json", Object (Map [ "hello", String "world" ]) ])
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with missing value`` () =
     Json.deserialize testJsonWithMissingOption =! testInstanceWithNoneOption
 
-[<Test>]
+[<Fact>]
 let ``Json.serialize with default value`` () =
     Json.serialize testInstanceWithNoneOption =! testJsonWithMissingOption
 
@@ -269,17 +269,17 @@ let testJsonWithNoValues =
           "number", Number 42M
           "json", Object (Map [ "hello", String "world" ]) ])
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with invalid value includes missing member name in quotes`` () =
     let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
     test <@ match result with Choice2Of2 e -> e.Contains("'values'") @>
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with invalid value includes JSON formatted object`` () =
     let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
     test <@ match result with Choice2Of2 e -> e.EndsWith(Json.formatWith JsonFormattingOptions.SingleLine testJsonWithNoValues) @>
 
-[<Test>]
+[<Fact>]
 let ``Json.serialize with simple types returns correct values`` () =
 
     (* Bool *)
@@ -310,7 +310,7 @@ let ``Json.serialize with simple types returns correct values`` () =
 
     Json.serialize "hello" =! String "hello"
 
-[<Test>]
+[<Fact>]
 let ``Json.serialize with custom types returns correct values`` () =
     Json.serialize testInstance =! testJson
 
@@ -336,15 +336,15 @@ let testUnionJson =
     Object (Map.ofList
         [ "two", Array [ Number 42M; Bool true ] ])
 
-[<Test>]
+[<Fact>]
 let ``Json.serialize with union types remains tractable`` () =
     Json.serialize testUnion =! testUnionJson
 
-[<Test>]
+[<Fact>]
 let ``Json.deserialize with union types remains tractable`` () =
     Json.deserialize testUnionJson =! testUnion
 
-[<Test>]
+[<Fact>]
 let ``Json.format escapes object keys correctly`` () =
     let data = Map [ "\u001f", "abc" ]
     let serialized = Json.serialize data
@@ -378,10 +378,10 @@ type MyDayOfWeekObject =
 let deserializedMonday = { Bool = true; Day = DayOfWeek.Monday }
 let serializedMonday = Object (Map.ofList ["bool", Bool true; "day_of_week", String "Monday"])
 
-[<Test>]
+[<Fact>]
 let ``Json.readWith allows using a custom deserialization function`` () =
     Json.deserialize serializedMonday =! deserializedMonday
 
-[<Test>]
+[<Fact>]
 let ``Json.writeWith allows using a custom serialization function`` () =
     Json.serialize deserializedMonday =! serializedMonday

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -272,12 +272,12 @@ let testJsonWithNoValues =
 [<Fact>]
 let ``Json.deserialize with invalid value includes missing member name in quotes`` () =
     let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
-    test <@ match result with Choice2Of2 e -> e.Contains("'values'") @>
+    test <@ match result with Choice2Of2 e -> e.Contains("'values'") | _ -> false @>
 
 [<Fact>]
 let ``Json.deserialize with invalid value includes JSON formatted object`` () =
     let result : Choice<Test,_> = Json.tryDeserialize testJsonWithNoValues
-    test <@ match result with Choice2Of2 e -> e.EndsWith(Json.formatWith JsonFormattingOptions.SingleLine testJsonWithNoValues) @>
+    test <@ match result with Choice2Of2 e -> e.EndsWith(Json.formatWith JsonFormattingOptions.SingleLine testJsonWithNoValues) | _ -> false @>
 
 [<Fact>]
 let ``Json.serialize with simple types returns correct values`` () =

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj
@@ -57,6 +57,7 @@
   -->
   <ItemGroup>
     <Compile Include="Chiron.Tests.fs" />
+    <Compile Include="Chiron.Testing.fs" />
     <Compile Include="Chiron.Properties.fs" />
     <Content Include="App.config" />
   </ItemGroup>

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name>Chiron.Tests</Name>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -119,6 +120,111 @@
       <ItemGroup>
         <Reference Include="Unquote">
           <HintPath>..\..\packages\test\Unquote\lib\net45\Unquote.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.assert">
+          <HintPath>..\..\packages\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
+      <PropertyGroup>
+        <__paket__xunit_core_props>win81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <PropertyGroup>
+        <__paket__xunit_core_props>wpa81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <PropertyGroup>
+        <__paket__xunit_core_props>portable-net45+win8+wp8+wpa81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0') Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.core">
+          <HintPath>..\..\packages\xunit.extensibility.core\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\win8\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="xunit.execution.desktop">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\net45\xunit.execution.desktop.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monoandroid\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monotouch\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\wp8\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\xamarinios\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\portable-net45+win8+wp8+wpa81\xunit.execution.dotnet.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj
@@ -96,8 +96,8 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
-        <Reference Include="FSharp.Core">
-          <HintPath>..\..\packages\test\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+        <Reference Include="FsCheck.Xunit">
+          <HintPath>..\..\packages\test\FsCheck.Xunit\lib\net45\FsCheck.Xunit.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -107,8 +107,8 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
-        <Reference Include="nunit.framework">
-          <HintPath>..\..\packages\test\NUnit\lib\nunit.framework.dll</HintPath>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\test\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -127,10 +127,21 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="xunit.abstractions">
+          <HintPath>..\..\packages\test\xunit.abstractions\lib\net35\xunit.abstractions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="xunit.assert">
-          <HintPath>..\..\packages\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+          <HintPath>..\..\packages\test\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -138,28 +149,10 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
-      <PropertyGroup>
-        <__paket__xunit_core_props>win81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
-      <PropertyGroup>
-        <__paket__xunit_core_props>wpa81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <PropertyGroup>
-        <__paket__xunit_core_props>portable-net45+win8+wp8+wpa81\xunit.core</__paket__xunit_core_props>
-      </PropertyGroup>
-    </When>
-  </Choose>
-  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0') Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="xunit.core">
-          <HintPath>..\..\packages\xunit.extensibility.core\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+          <HintPath>..\..\packages\test\xunit.extensibility.core\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -167,64 +160,10 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5'">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\win8\xunit.execution.dotnet.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="xunit.execution.desktop">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\net45\xunit.execution.desktop.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monoandroid\xunit.execution.dotnet.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monotouch\xunit.execution.dotnet.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\wp8\xunit.execution.dotnet.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\xamarinios\xunit.execution.dotnet.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="xunit.execution.dotnet">
-          <HintPath>..\..\packages\xunit.extensibility.execution\lib\portable-net45+win8+wp8+wpa81\xunit.execution.dotnet.dll</HintPath>
+          <HintPath>..\..\packages\test\xunit.extensibility.execution\lib\net45\xunit.execution.desktop.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
@@ -1,9 +1,7 @@
 Aether
-
 group Test
-
-  FSharp.Core
-  FsCheck
-  NUnit
-  Unquote
-  xunit
+FSharp.Core
+FsCheck
+Unquote
+xunit
+FsCheck.Xunit

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj.paket.references
@@ -6,3 +6,4 @@ group Test
   FsCheck
   NUnit
   Unquote
+  xunit


### PR DESCRIPTION
This converts the existing tests over to xUnit, adds them inline to the build script, and updates the suite with several property-based tests for the primitive types that Chiron supports out of the box.