### PR TITLE
Fix round-trip parsing of DateTimeOffset values

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -788,7 +788,7 @@ module Mapping =
 
         static member inline FromJson (_: DateTimeOffset) =
                 fun x ->
-                    match DateTimeOffset.TryParseExact (x, [|"yyyy-MM-dd'T'HH:mm:ss.FFFK" |], null, DateTimeStyles.None) with
+                    match DateTimeOffset.TryParseExact (x, [| "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'"; "o"; "r" |], null, DateTimeStyles.AssumeUniversal) with
                     | true, x -> Json.init x
                     | _ -> Json.error "datetimeoffset"
             =<< Json.Optic.get Json.String_


### PR DESCRIPTION
Fixes an error in the round-trip handling of `DateTimeOffset` values. Assumes that values with out any offset data are in UTC.