### PR TITLE
Adding To/From Json methods for tuples with 4 and 5 elements.

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -886,6 +886,29 @@ module Mapping =
                             Json.error "tuple3"
             =<< Json.Optic.get Json.Array_
 
+        static member inline FromJson (_: 'a * 'b * 'c * 'd) : Json<'a * 'b * 'c * 'd> =
+                function | a :: b :: c :: [d] ->
+                                fun a b c d -> a, b, c, d
+                            <!> Json.ofResult (fromJson a)
+                            <*> Json.ofResult (fromJson b)
+                            <*> Json.ofResult (fromJson c)
+                            <*> Json.ofResult (fromJson d)
+                         | _ ->
+                            Json.error "tuple4"
+            =<< Json.Optic.get Json.Array_
+
+        static member inline FromJson (_: 'a * 'b * 'c * 'd * 'e) : Json<'a * 'b * 'c * 'd * 'e> =
+                function | a :: b :: c :: d :: [e] ->
+                                fun a b c d e -> a, b, c, d, e
+                            <!> Json.ofResult (fromJson a)
+                            <*> Json.ofResult (fromJson b)
+                            <*> Json.ofResult (fromJson c)
+                            <*> Json.ofResult (fromJson d)
+                            <*> Json.ofResult (fromJson e)
+                         | _ ->
+                            Json.error "tuple5"
+            =<< Json.Optic.get Json.Array_
+
     (* To
     
         *)
@@ -999,6 +1022,12 @@ module Mapping =
 
         static member inline ToJson ((a, b, c)) =
             Json.Optic.set id_ (Array [ toJson a; toJson b; toJson c ])
+
+        static member inline ToJson ((a, b, c, d)) =
+            Json.Optic.set id_ (Array [ toJson a; toJson b; toJson c; toJson d ])
+
+        static member inline ToJson ((a, b, c, d, e)) =
+            Json.Optic.set id_ (Array [ toJson a; toJson b; toJson c; toJson d; toJson e ])
 
     (* Functions
 

--- a/tests/Chiron.Tests/Chiron.Properties.fs
+++ b/tests/Chiron.Tests/Chiron.Properties.fs
@@ -109,3 +109,36 @@ type TestRecord =
 let ``TestRecord can be round-tripped`` (v : TestRecord) =
     (v.StringField <> null) ==> lazy
         doRoundTripTest v
+
+type TestUnion =
+    | CaseWithTwoArgs of string * int
+    | CaseWithThreeArgs of string * int * bool
+    | CaseWithFourArgs of string * int * bool * System.Guid
+    | CaseWithFiveArgs of string * int * bool * System.Guid * System.DateTimeOffset
+
+    member this.StringField =
+        match this with
+        | CaseWithTwoArgs (s, _) -> s
+        | CaseWithThreeArgs (s, _, _) -> s
+        | CaseWithFourArgs (s, _, _, _) -> s
+        | CaseWithFiveArgs (s, _, _, _, _) -> s
+
+    static member ToJson (x: TestUnion) =
+        match x with
+        | CaseWithTwoArgs (a1, a2) -> Json.write "CaseWithTwoArgs" (a1, a2)
+        | CaseWithThreeArgs (a1, a2, a3) -> Json.write "CaseWithThreeArgs" (a1, a2, a3)
+        | CaseWithFourArgs (a1, a2, a3, a4) -> Json.write "CaseWithFourArgs" (a1, a2, a3, a4)
+        | CaseWithFiveArgs (a1, a2, a3, a4, a5) -> Json.write "CaseWithFiveArgs" (a1, a2, a3, a4, a5)
+
+    static member FromJson (_ : TestUnion) =
+        function
+        | Property "CaseWithTwoArgs" (a1, a2) as json -> Json.init (CaseWithTwoArgs (a1, a2)) json
+        | Property "CaseWithThreeArgs" (a1, a2, a3) as json -> Json.init (CaseWithThreeArgs (a1, a2, a3)) json
+        | Property "CaseWithFourArgs" (a1, a2, a3, a4) as json -> Json.init (CaseWithFourArgs (a1, a2, a3, a4)) json
+        | Property "CaseWithFiveArgs" (a1, a2, a3, a4, a5) as json -> Json.init (CaseWithFiveArgs (a1, a2, a3, a4, a5)) json
+        | json -> Json.error (sprintf "couldn't deserialise %A" json) json
+
+[<Property>]
+let ``TestUnion can be round-tripped`` (v : TestUnion) =
+    (v.StringField <> null) ==> lazy
+        doRoundTripTest v

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -192,6 +192,12 @@ let ``Json.deserialize complex types returns correct values`` () =
     Json.deserialize (Array [ String "hello"; Number 42M ])
         =! ("hello", 42)
 
+    Json.deserialize (Array [ String "hello"; Number 42M; Bool true ])
+        =! ("hello", 42, true)
+
+    Json.deserialize (Array [ String "hello"; Number 42M; Bool true; Number 12M ])
+        =! ("hello", 42, true, 12)
+
 type Test =
     { String: string
       Number : int option


### PR DESCRIPTION
Not sure if there was a good reason for the limitation up to three-item tuples, but I found it very inconvenient.