### PR TITLE
Added serializeWith method

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -985,6 +985,9 @@ module Mapping =
     let inline internal toJson (x: 'a) =
         snd (toJsonDefaults (x, ToJsonDefaults) (Object (Map.empty)))
 
+    let inline internal toJsonWith (f:'a -> unit Json) (x: 'a) = 
+        snd (f x (Object (Map.empty))) 
+
     (* Defaults *)
 
     type ToJsonDefaults with
@@ -1097,6 +1100,9 @@ module Mapping =
 
         let inline serialize a =
             toJson a
+
+        let inline serializeWith f a = 
+            toJsonWith f a
 
 (* Patterns
 

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -317,6 +317,37 @@ let ``Json.serialize with simple types returns correct values`` () =
     Json.serialize "hello" =! String "hello"
 
 [<Fact>]
+let ``Json.serializeWith with simple types returns correct values`` () =
+
+    (* Bool *)
+
+    Json.serializeWith ((fun x -> x.ToString()) >> Json.Optic.set Json.String_) true =! String "True"
+
+    (* Numeric *)
+
+    Json.serializeWith ((fun x -> x / 2M) >> Json.Optic.set Json.Number_) (decimal 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (float 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (int 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (int16 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (int64 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (single 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (uint16 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (uint32 42) =! Number 21M
+    Json.serializeWith (decimal >> (fun x -> x / 2M) >> (Json.Optic.set Json.Number_)) (uint64 42) =! Number 21M
+
+    (* DateTime *)
+
+    Json.serializeWith (fun (x:DateTime) -> Json.Optic.set Json.String_ (x.ToString("yyyy-MM-dd"))) (DateTime (2015, 2, 20, 14, 36, 21, DateTimeKind.Utc)) =! String "2015-02-20"
+
+    (* DateTimeOffset *)
+
+    Json.serializeWith (fun (x:DateTimeOffset) -> Json.Optic.set Json.String_ (x.ToString("yyyy-MM-dd"))) (DateTimeOffset (2015, 2, 20, 14, 36, 21, TimeSpan.Zero)) =! String "2015-02-20"
+
+    (* String *)
+
+    Json.serializeWith (fun (x:string) -> Json.Optic.set Json.String_ (string x.[3..])) "hello" =! String "lo"
+
+[<Fact>]
 let ``Json.serialize with custom types returns correct values`` () =
     Json.serialize testInstance =! testJson
 


### PR DESCRIPTION
I have added a convenience method `serializeWith` which allows you to delegate to a function. An example might be truncating the time component of a DateTime . 

     Json.serializeWith (fun (x:DateTime) -> Json.Optic.set Json.String_ (x.ToString("yyyy-MM-dd"))) (DateTime (2015, 2, 20, 14, 36, 21, DateTimeKind.Utc)) =! String "2015-02-20" 

this is also useful when you cannot enhance a type with the `ToJson` method because you may not know the closed form of the type. For example `Result<'a, Error>` in this case I can't create an extension method as the F# compiler doesn't support it, so this PR lets me do something like, 

     let inline serializeResult (r:Result<'a, Error>) =  
          match r with
          | Success v -> Json.write "success" v
          | Failure f -> Json.write "failure" f
    
     Json.serializeWith serializeResult r

I'm only playing with this seriously for the first time but I couldn't see any obvious way of doing what I wanted to achieve. Open to suggestions if there is a way to do this. 