### PR TITLE
Better escaping performance

### DIFF
--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -1,4 +1,4 @@
-﻿module Chiron
+module Chiron
 
 open System
 open System.Globalization
@@ -1130,3 +1130,6 @@ module Patterns =
             Optic.get (Json.Object_ >?> Map.key_ key)
          >> Option.bind (Json.tryDeserialize >> function | Choice1Of2 a -> Some a
                                                          | _ -> None)
+
+[<assembly:System.Runtime.CompilerServices.InternalsVisibleTo("Chiron.Tests")>]
+()

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -379,26 +379,66 @@ module internal Escaping =
     let parse =
         many charP
 
-    let escape (s: string) =
-        let rec escape r =
-            function | [] -> r
-                     | h :: t when (unescaped (int h)) ->
-                        escape (r @ [ h ]) t
-                     | h :: t ->
-                        let n =
-                            match h with
-                            | '"'  -> [ '\\'; '"' ]
-                            | '\\' -> [ '\\'; '\\' ]
-                            | '\b' -> [ '\\'; 'b' ]
-                            | '\f' -> [ '\\'; 'f' ]
-                            | '\n' -> [ '\\'; 'n' ]
-                            | '\r' -> [ '\\'; 'r' ]
-                            | '\t' -> [ '\\'; 't' ]
-                            | x ->    [ '\\'; 'u' ] @ [ for c in (((int x).ToString ("X4")).ToCharArray ()) -> c ]
+    let private escapeChars =
+        [| '"'; '\\'; '\n'; '\r'; '\t'; '\b'; '\f'
+           '\u0000'; '\u0001'; '\u0002'; '\u0003'
+           '\u0004'; '\u0005'; '\u0006'; '\u0007'
+           '\u000B'; '\u000E'; '\u000F'
+           '\u0010'; '\u0011'; '\u0012'; '\u0013'
+           '\u0014'; '\u0015'; '\u0016'; '\u0017'
+           '\u0018'; '\u0019'; '\u001A'; '\u001B'
+           '\u001C'; '\u001D'; '\u001E'; '\u001F' |]
 
-                        escape (r @ n) t
-
-        new string (List.toArray (escape [] [ for c in (s.ToCharArray ()) -> c ]))
+    let escape (s: string) : string =
+        let mutable nextEscapeIndex = s.IndexOfAny(escapeChars)
+        if nextEscapeIndex = -1 then s else
+        let sb = System.Text.StringBuilder(String.length s)
+        let mutable lastIndex = 0
+        while (nextEscapeIndex <> -1) do
+            if nextEscapeIndex > lastIndex then
+                sb.Append(s, lastIndex, nextEscapeIndex - lastIndex) |> ignore
+            match s.[nextEscapeIndex] with
+            | '"' -> sb.Append @"\"""
+            | '\\' -> sb.Append @"\\"
+            | '\n' -> sb.Append @"\n"
+            | '\r' -> sb.Append @"\r"
+            | '\t' -> sb.Append @"\t"
+            | '\f' -> sb.Append @"\f"
+            | '\b' -> sb.Append @"\b"
+            | '\u0000' -> sb.Append @"\u0000"
+            | '\u0001' -> sb.Append @"\u0001"
+            | '\u0002' -> sb.Append @"\u0002"
+            | '\u0003' -> sb.Append @"\u0003"
+            | '\u0004' -> sb.Append @"\u0004"
+            | '\u0005' -> sb.Append @"\u0005"
+            | '\u0006' -> sb.Append @"\u0006"
+            | '\u0007' -> sb.Append @"\u0007"
+            | '\u000B' -> sb.Append @"\u000B"
+            | '\u000E' -> sb.Append @"\u000E"
+            | '\u000F' -> sb.Append @"\u000F"
+            | '\u0010' -> sb.Append @"\u0010"
+            | '\u0011' -> sb.Append @"\u0011"
+            | '\u0012' -> sb.Append @"\u0012"
+            | '\u0013' -> sb.Append @"\u0013"
+            | '\u0014' -> sb.Append @"\u0014"
+            | '\u0015' -> sb.Append @"\u0015"
+            | '\u0016' -> sb.Append @"\u0016"
+            | '\u0017' -> sb.Append @"\u0017"
+            | '\u0018' -> sb.Append @"\u0018"
+            | '\u0019' -> sb.Append @"\u0019"
+            | '\u001A' -> sb.Append @"\u001A"
+            | '\u001B' -> sb.Append @"\u001B"
+            | '\u001C' -> sb.Append @"\u001C"
+            | '\u001D' -> sb.Append @"\u001D"
+            | '\u001E' -> sb.Append @"\u001E"
+            | '\u001F' -> sb.Append @"\u001F"
+            | c -> sb.Append(@"\u").Append((int c).ToString("X4"))
+            |> ignore
+            lastIndex <- nextEscapeIndex + 1
+            nextEscapeIndex <- s.IndexOfAny(escapeChars, lastIndex)
+        if lastIndex < String.length s then
+            sb.Append (s, lastIndex, String.length s - lastIndex) |> ignore
+        sb.ToString()
 
 (* Parsing
 

--- a/tests/Chiron.Tests/Chiron.Tests.fs
+++ b/tests/Chiron.Tests/Chiron.Tests.fs
@@ -124,6 +124,28 @@ let ``Json.format returns correct values`` () =
     Json.format (String "푟") =! "\"푟\""
     Json.format (String "\t") =! "\"\\t\""
 
+[<Fact>]
+let ``escape is not pathological for cases with escapes`` () =
+    let testObj =
+        Json.Array
+            [ for i in 1..100000 do
+                yield Json.String <| "he\nllo\u0006\t 푟 " + string i ]
+    let testString = Json.format testObj
+    let sw = System.Diagnostics.Stopwatch.StartNew()
+    let escaped = Escaping.escape testString
+    let time = sw.ElapsedMilliseconds
+    printfn "String length: %i, JSON escaped length: %i, Time: %i ms" (String.length testString) (String.length escaped) time
+    Assert.InRange(time, 0L, 5000L)
+
+[<Fact>]
+let ``escape is not pathological for non-escaped cases`` () =
+    let testString = String.replicate 2500000 "a"
+    let sw = System.Diagnostics.Stopwatch.StartNew()
+    let escaped = Escaping.escape testString
+    let time = sw.ElapsedMilliseconds
+    printfn "String length: %i, JSON escaped length: %i, Time: %i ms" (String.length testString) (String.length escaped) time
+    Assert.InRange(time, 0L, 5000L)
+
 (* Mapping
 
    Tests exercising mapping functions between Json and other F#


### PR DESCRIPTION
This is a more efficient algorithm for escaping a JSON string. The new process has time and space complexity of `O(n)` where `n` is the length of the string to be escaped (if I account properly), and requires no more than 2 full scans of the string in the worst case and 1 full scan of the string.

In the event a string has none of the characters which need to be escaped, the input string will be returned without additional allocations. Otherwise, a string builder will be allocated with initial capacity set to the length of the input string. For the cost of an additional scan of the string, we could determine the exact length of the output string. Testing indicated that this added extra overhead cost without significant benefit. Then we step through the string, stopping at each character which needs to be escaped and adding the unescaped characters and expanding the target characters. Once we have processed all the values which must be escaped, we return the new string from the string builder.

Also included is a table of escape characters. These are all the characters in UTF-8 that need escaping for JSON. Unicode characters beyond `U+FFFF` should not need to be further escaped due to encoding the value in UTF-8. As `String.IndexOfAny` does not take a predicate, this array is necessary to take advantage of the internal BCL optimizations.

On my hardware, I am achieving ~4ms for 2.5MB of string that needs no escaping and ~75ms for 2.5MB of string with significant escaping required.