### PR TITLE
Merge chiron-6 build updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ paket-files
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 .fake/

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ script:
 branches:
   except:
     - gh-pages
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
 language: csharp
 
-mono: 5.2.0
-dotnet: 2.0.0
+dotnet: 2.1.402
+
+mono:
+- 5.2.0
 
 install:
-  - mozroots --import --sync
-  # workaround for missing .net 4.5 targing pack
-  - export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
+- mozroots --import --sync
+# workaround for missing .net 4.5 targing pack
+- export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
 
 matrix:
-  include:
+    include:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 2.0.0
+      dotnet: 2.1.402
     - os: osx # OSX 10.12
       osx_image: xcode9.1
-      dotnet: 2.0.0
+      dotnet: 2.1.402
       dist: trusty
       sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release
-  - dotnet test --no-build -c Release tests\Chiron.Tests\Chiron.Tests.fsproj
+  - dotnet test --no-build -c Release tests/Chiron.Tests/Chiron.Tests.fsproj
   - dotnet pack --no-build -c Release src/Chiron
   #- dotnet benchmarks\Chiron.Benchmarks\bin\Release\netcoreapp2.0\Chiron.Benchmarks.dll --class SwaggerSchema
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ script:
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release
-  - dotnet test -c Release tests\Chiron.Tests\Chiron.Tests.fsproj
-  - dotnet pack -c Release
-  - dotnet benchmarks\Chiron.Benchmarks\bin\Release\netcoreapp2.0\Chiron.Benchmarks.dll --class SwaggerSchema
+  - dotnet test --no-build -c Release tests\Chiron.Tests\Chiron.Tests.fsproj
+  - dotnet pack --no-build -c Release src/Chiron
+  #- dotnet benchmarks\Chiron.Benchmarks\bin\Release\netcoreapp2.0\Chiron.Benchmarks.dll --class SwaggerSchema
 
 branches:
   except:

--- a/Chiron.sln
+++ b/Chiron.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,9 @@
-version: 7.0.0-aci-{build}
-
 image: Visual Studio 2017
-
 build_script:
-  - ps: dotnet --info
-  - ps: dotnet restore
-  - ps: dotnet build -c Release --version-suffix "aci-${env:APPVEYOR_BUILD_NUMBER}"
-  - ps: dotnet test -c Release tests\Chiron.Tests\Chiron.Tests.fsproj
-  - ps: dotnet pack -c Release --version-suffix "aci-${env:APPVEYOR_BUILD_NUMBER}"
-  - ps: dotnet benchmarks\Chiron.Benchmarks\bin\Release\netcoreapp2.0\Chiron.Benchmarks.dll --class SwaggerSchema
-
+  - ps: |
+      .\build.ps1
+      if ($lastexitcode -ne 0){ exit $lastexitcode }
 test: off
-
 artifacts:
-  - path: '**\*.nupkg'
+  - path: bin\*.nupkg
   - path: '**\BenchmarkDotNet.Artifacts\**\*.*'

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,22 @@
+[xml]$doc = Get-Content .\src\Directory.Build.props
+$version = $doc.Project.PropertyGroup.VersionPrefix # the version under development, update after a release
+$versionSuffix = '-build.0' # manually incremented for local builds
+
+function isVersionTag($tag){
+    $v = New-Object Version
+    [Version]::TryParse($tag, [ref]$v)
+}
+
+if ($env:appveyor){
+    $versionSuffix = '-build.' + $env:appveyor_build_number
+    if ($env:appveyor_repo_tag -eq 'true' -and (isVersionTag($env:appveyor_repo_tag_name))){
+        $version = $env:appveyor_repo_tag_name
+        $versionSuffix = ''
+    }
+    Update-AppveyorBuild -Version "$version$versionSuffix"
+}
+
+dotnet build -c Release Chiron.sln /p:Version=$version$versionSuffix
+dotnet test --no-build -c Release tests/Chiron.Tests/Chiron.Tests.fsproj
+dotnet pack --no-build -c Release src/Chiron /p:Version=$version$versionSuffix -o $psscriptroot/bin
+# dotnet benchmarks\Chiron.Benchmarks\bin\Release\netcoreapp2.0\Chiron.Benchmarks.dll --class SwaggerSchema

--- a/src/Chiron/Chiron.fs
+++ b/src/Chiron/Chiron.fs
@@ -879,7 +879,7 @@ module Serialization =
                 | Some a -> buildWith a jObj
                 | None -> jObj
 
-            let ref (): JsonEncoder<'a> ref * JsonEncoder<'a> =
+            let ref<'a> (): JsonEncoder<'a> ref * JsonEncoder<'a> =
                 let innerRef = ref (Unchecked.defaultof<JsonEncoder<'a>>)
                 innerRef, (fun a -> (!innerRef) a)
 
@@ -1152,7 +1152,7 @@ module Serialization =
                     Encode.jsonObject jObj
                     |> decode
 
-            let ref (): Decoder<'s,'a> ref * Decoder<'s,'a> =
+            let ref<'s, 'a> (): Decoder<'s,'a> ref * Decoder<'s,'a> =
                 let innerRef = ref (Unchecked.defaultof<Decoder<'s,'a>>)
                 innerRef, (fun s -> (!innerRef) s)
 

--- a/src/Chiron/Chiron.fsproj
+++ b/src/Chiron/Chiron.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <VersionPrefix>7.0.0</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -8,10 +8,9 @@
     <!--<Compile Include="Chiron.fsi" />-->
     <Compile Include="Chiron.fs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">
-    <PackageReference Include="FParsec" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+  <ItemGroup>
+    <PackageReference Include="Aether" Version="8.2.0" />
     <PackageReference Include="FParsec" Version="1.0.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Chiron/Chiron.fsproj
+++ b/src/Chiron/Chiron.fsproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <VersionPrefix>7.0.0</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
@@ -11,6 +10,5 @@
   <ItemGroup>
     <PackageReference Include="Aether" Version="8.2.0" />
     <PackageReference Include="FParsec" Version="1.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/Chiron.Tests/Chiron.Tests.fsproj
+++ b/tests/Chiron.Tests/Chiron.Tests.fsproj
@@ -8,15 +8,17 @@
     <Compile Include="Chiron.Tests.fs" />
     <Compile Include="Chiron.Testing.fs" />
     <Compile Include="Chiron.Properties.fs" />
-    <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.*" />
-    <PackageReference Include="xunit" Version="2.3.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.*" />
-    <PackageReference Include="Unquote" Version="4.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.*" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0-*" />
     <PackageReference Include="FsCheck" Version="3.0.0-*" />
+    <PackageReference Include="Unquote" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Chiron\Chiron.fsproj" />

--- a/tests/Chiron.Tests/Program.fs
+++ b/tests/Chiron.Tests/Program.fs
@@ -1,2 +1,0 @@
-module DummyMain = let main _ = 0
-#nowarn "988"


### PR DESCRIPTION
Seems like a rebase may be in order here, but I thought I would at least push this up for review.

Current issues/improvements:
- [x] version is retrieved from `src/Directory.Build.props` rather than hard-coded
- [ ] Benchmarks are not currently run in AppVeyor build and fail to compile
- [x] Build fails on Travis apparently due to source link