### PR TITLE
Setting minimum FSharp.Core to 4.3.4

### DIFF
--- a/src/Chiron/Chiron.fsproj
+++ b/src/Chiron/Chiron.fsproj
@@ -19,7 +19,7 @@
     <Compile Include="Chiron.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.5.2" />
+    <PackageReference Update="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Aether" Version="8.2.0" />
     <PackageReference Include="FParsec" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />

--- a/src/Chiron/Chiron.fsproj
+++ b/src/Chiron/Chiron.fsproj
@@ -19,7 +19,7 @@
     <Compile Include="Chiron.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.2.3" />
+    <PackageReference Update="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Aether" Version="8.2.0" />
     <PackageReference Include="FParsec" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />


### PR DESCRIPTION
Targeting lower FSharp.Core version as specified in the [Engineering Guidance](https://fsharp.github.io/2015/04/18/fsharp-core-notes.html#libraries-should-target-lower-versions-of-fsharpcore).

>As of February 2018 new editions of F# libraries should generally do the following:
>
>* Be netstandard1.6, or netstandard2.0 with an additional .NET Framework 4.5 (net45) build
>* Use FSharp.Core nuget 4.2.3 (assembly version 4.4.1.0) or 4.3.3 (assembly version 4.4.3.0)
